### PR TITLE
FIX: typo in kernel_namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ return [
 
     'clear_before_export' => true,
 
-    'kernal_namespace' => 'App\Http\Kernel',
+    'kernel_namespace' => 'App\Http\Kernel',
 ];
 ```
 

--- a/config/static-export.php
+++ b/config/static-export.php
@@ -5,5 +5,5 @@ return [
 
     'clear_before_export' => true,
 
-    'kernal_namespace' => 'App\Http\Kernel',
+    'kernel_namespace' => 'App\Http\Kernel',
 ];

--- a/src/Export.php
+++ b/src/Export.php
@@ -29,7 +29,7 @@ class Export
     {
         $request = Request::create($url);
 
-        $kernel = app(config('static-export.kernal_namespace'));
+        $kernel = app(config('static-export.kernel_namespace'));
         $response = $kernel->handle($request);
 
         return $response->getContent();


### PR DESCRIPTION
## About this PR

Update `kernal_namespace` to `kernel_namespace` 😉 